### PR TITLE
[16.0][REM] account_move_name_sequence: remove from container

### DIFF
--- a/accountancy_install/__manifest__.py
+++ b/accountancy_install/__manifest__.py
@@ -38,7 +38,6 @@
         'account_move_line_purchase_info',
         'account_move_line_sale_info',
         'account_move_line_tax_editable',
-        'account_move_name_sequence',
         'account_move_print',
         'account_usability',
         'base_vat_optional_vies',

--- a/community_org_install/__manifest__.py
+++ b/community_org_install/__manifest__.py
@@ -148,7 +148,6 @@
         'account_move_line_sale_info',
         'account_move_line_stock_info',
         'account_move_line_tax_editable',
-        'account_move_name_sequence',
         'account_move_print',
         'base_vat_optional_vies',
         'product_category_tax',

--- a/container_install_basis/__manifest__.py
+++ b/container_install_basis/__manifest__.py
@@ -29,7 +29,6 @@
         "account_invoice_constraint_chronology",
         "account_journal_lock_date",
         "account_lock_date_update",
-        "account_move_name_sequence",
         "account_move_print",
         "account_usability",
         "base_vat_optional_vies",

--- a/package.txt
+++ b/package.txt
@@ -88,7 +88,6 @@ oca/account_move_line_purchase_info
 oca/account_move_line_sale_info
 oca/account_move_line_stock_info
 oca/account_move_line_tax_editable
-oca/account_move_name_sequence
 oca/account_move_print
 oca/account_move_tier_validation
 oca/account_payment_mode

--- a/services_org_install/__manifest__.py
+++ b/services_org_install/__manifest__.py
@@ -135,7 +135,6 @@
         'account_move_line_purchase_info',
         'account_move_line_sale_info',
         'account_move_line_tax_editable',
-        'account_move_name_sequence',
         'account_move_print',
         'base_vat_optional_vies',
         'product_category_tax',


### PR DESCRIPTION
Based on the discussion in https://github.com/onesteinbv/addons-container/issues/41, I open this PR with the removal of the OCA module `account_move_name_sequence` from the container package. Once a final decision on discussion in https://github.com/onesteinbv/addons-container/issues/41 will be made, this PR can be merged.