### PR TITLE
[UPD] base_module_bundle: Add category Bundles to Apps view

### DIFF
--- a/base_module_bundle/__init__.py
+++ b/base_module_bundle/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizards
+from .hooks import post_init_hook

--- a/base_module_bundle/__manifest__.py
+++ b/base_module_bundle/__manifest__.py
@@ -4,7 +4,8 @@
     "version": "18.0.1.0.0",
     "author": "Onestein",
     "website": "https://onestein.nl",
-    "depends": ["base_setup"],
-    "data": [],
+    "depends": ["base_setup", "base_import_module"],
+    "data": ["views/ir_module_module_views.xml"],
     "license": "AGPL-3",
+    "post_init_hook": "post_init_hook",
 }

--- a/base_module_bundle/hooks.py
+++ b/base_module_bundle/hooks.py
@@ -1,0 +1,8 @@
+def post_init_hook(env):
+    ir_module_module_obj = env["ir.module.module"]
+    modules = ir_module_module_obj.sudo().search([])
+    bundle_modules = ir_module_module_obj
+    for module in modules:
+        if module.get_module_info(module.name).get("bundle", False):
+            bundle_modules += module
+    bundle_modules.write({"module_type": "bundles"})

--- a/base_module_bundle/models/ir_module_module.py
+++ b/base_module_bundle/models/ir_module_module.py
@@ -1,4 +1,4 @@
-from odoo import conf, fields, models
+from odoo import api, conf, fields, models
 
 
 class IrModuleModule(models.Model):
@@ -8,6 +8,9 @@ class IrModuleModule(models.Model):
         help="A bundle purges dependencies on uninstallation of this module",
         compute="_compute_is_bundle",
     )  # Can't be stored
+    module_type = fields.Selection(
+        selection_add=[("bundles", "Bundles")], ondelete={"bundles": "set default"}
+    )
 
     def _compute_is_bundle(self):
         for module in self:
@@ -51,3 +54,25 @@ class IrModuleModule(models.Model):
             modules_to_remove.write({"state": "to remove"})
 
         return super().button_uninstall()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        modules = super().create(vals_list)
+        bundle_modules = self
+        for module in modules:
+            if module.get_module_info(module.name).get("bundle", False):
+                bundle_modules += module
+        bundle_modules.write({"module_type": "bundles"})
+        return modules
+
+    def _update_from_terp(self, terp):
+        res = super()._update_from_terp(terp)
+        self._update_module_type(terp)
+        return res
+
+    def _update_module_type(self, terp):
+        if terp.get("bundle", False):
+            self.module_type = "bundles"
+        else:
+            if self.module_type == "bundles":
+                self.module_type = "official"

--- a/base_module_bundle/views/ir_module_module_views.xml
+++ b/base_module_bundle/views/ir_module_module_views.xml
@@ -1,0 +1,51 @@
+<odoo>
+    <record model="ir.ui.view" id="module_view_kanban_apps_inherit">
+        <field name="name">Apps Kanban Data Modules</field>
+        <field name="model">ir.module.module</field>
+        <field name="inherit_id" ref="base_import_module.module_view_kanban_apps_inherit"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='button_immediate_install_app'][1]" position="attributes">
+                <attribute name="invisible">state != 'uninstalled' or module_type in ('official','bundles', False)
+                </attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_immediate_install_app'][2]" position="attributes">
+                <attribute name="invisible">state == 'uninstalled' or module_type in ('official','bundles', False)
+                </attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_immediate_install']" position="attributes">
+                <attribute name="invisible">state != 'uninstalled' or (module_type and module_type not in
+                    ('official','bundles'))
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="module_form_apps_inherit">
+        <field name="name">Apps</field>
+        <field name="model">ir.module.module</field>
+        <field name="inherit_id" ref="base_import_module.module_form_apps_inherit"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='technical_data']" position="attributes">
+                <attribute name="invisible">module_type not in ('official','bundles')</attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_immediate_install_app'][1]" position="attributes">
+                <attribute name="invisible">state != 'uninstalled' or module_type in ('official','bundles', False)
+                </attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_immediate_install_app'][2]" position="attributes">
+                <attribute name="invisible">state == 'uninstalled' or module_type in ('official','bundles', False)
+                </attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_immediate_install']" position="attributes">
+                <attribute name="invisible">to_buy or state != 'uninstalled' or (module_type and module_type not in
+                    ('official','bundles'))
+                </attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_immediate_upgrade']" position="attributes">
+                <attribute name="invisible">state == 'uninstalled' or (module_type and module_type not in
+                    ('official','bundles'))
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Pr for https://github.com/onesteinbv/addons-curq/issues/347

I am thinking we should make all bundles as Apps, so that users don't need to remove the default 'Apps' filter when they want to check the 'Bundles' 

<img width="1431" height="301" alt="image" src="https://github.com/user-attachments/assets/932e9ef0-dd2a-42a5-a495-9d5cc8bab222" />

