### PR TITLE
[FIX] container_accessibility: Fix for access issue coming up for "ir…

### DIFF
--- a/container_accessibility/__manifest__.py
+++ b/container_accessibility/__manifest__.py
@@ -7,6 +7,7 @@
     "depends": [
         "base",
         "base_setup",
+        "base_automation",
         "mail",
         "privacy_lookup",
         "web_tour",

--- a/container_accessibility/menuitems.xml
+++ b/container_accessibility/menuitems.xml
@@ -16,6 +16,14 @@
         <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
     </record>
 
+    <record id="base.menu_ir_cron_act" model="ir.ui.menu">
+        <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
+    </record>
+
+    <record id="base.ir_cron_trigger_menu" model="ir.ui.menu">
+        <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
+    </record>
+
     <record id="base.reporting_menuitem" model="ir.ui.menu">
         <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
     </record>

--- a/container_accessibility/menuitems.xml
+++ b/container_accessibility/menuitems.xml
@@ -16,7 +16,11 @@
         <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
     </record>
 
-    <record id="base.menu_automation" model="ir.ui.menu">
+    <record id="base.menu_ir_cron_act" model="ir.ui.menu">
+        <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
+    </record>
+
+    <record id="base.ir_cron_trigger_menu" model="ir.ui.menu">
         <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
     </record>
 

--- a/container_accessibility/menuitems.xml
+++ b/container_accessibility/menuitems.xml
@@ -16,10 +16,6 @@
         <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
     </record>
 
-    <record id="base.menu_automation" model="ir.ui.menu">
-        <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
-    </record>
-
     <record id="base.reporting_menuitem" model="ir.ui.menu">
         <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
     </record>

--- a/container_accessibility/models/__init__.py
+++ b/container_accessibility/models/__init__.py
@@ -15,3 +15,5 @@ from . import server_config
 from . import fetchmail_server
 from . import ir_config_parameter
 from . import discuss_channel
+from . import base_automation
+from . import ir_actions_server

--- a/container_accessibility/models/base_automation.py
+++ b/container_accessibility/models/base_automation.py
@@ -1,0 +1,68 @@
+from odoo import api, fields, models
+
+TRIGGER_CHOICES = [
+    ("on_stage_set", "Stage is set to"),
+    ("on_user_set", "User is set"),
+    ("on_tag_set", "Tag is added"),
+    ("on_state_set", "State is set to"),
+    ("on_priority_set", "Priority is set to"),
+    ("on_archive", "On archived"),
+    ("on_unarchive", "On unarchived"),
+    ("on_create_or_write", "On save"),
+    ("on_create", "On creation"),  # deprecated, use 'on_create_or_write' instead
+    ("on_write", "On update"),  # deprecated, use 'on_create_or_write' instead
+    ("on_unlink", "On deletion"),
+    ("on_change", "On UI change"),
+    ("on_time", "Based on date field"),
+    ("on_time_created", "After creation"),
+    ("on_time_updated", "After last update"),
+    ("on_message_received", "On incoming message"),
+    ("on_message_sent", "On outgoing message"),
+    ("on_webhook", "On webhook"),
+]
+
+
+class BaseAutomation(models.Model):
+    _inherit = "base.automation"
+
+    @api.model
+    def _get_groups_to_restrict_trigger_choices(self):
+        """Hook to add groups to restrict choices.
+        :type : list
+        """
+        return ["container_accessibility.group_restricted"]
+
+    @api.model
+    def _get_trigger_choices_to_restrict(self):
+        """Hook to add choices to restrict.
+        :type : list
+        """
+        # We only need the keys (the first element of the tuples) to filter effectively
+        return ["on_create_or_write", "on_unlink", "on_change", "on_webhook"]
+
+    @api.model
+    def _get_trigger_selection_choices(self):
+        """Returns the filtered selection list."""
+        if any(
+            self.env.user.has_group(xml_id)
+            for xml_id in self._get_groups_to_restrict_trigger_choices()
+        ):
+            to_restrict = self._get_trigger_choices_to_restrict()
+            # Filter the list by checking if the key (item[0]) is in our removal set
+            return [
+                choice for choice in TRIGGER_CHOICES if choice[0] not in to_restrict
+            ]
+
+        return TRIGGER_CHOICES
+
+    trigger = fields.Selection(
+        selection=lambda self: self._get_trigger_selection_choices()
+    )
+
+    def _update_cron(self):
+        sudo_self = self
+        if self.env.user.is_restricted_user() and self.env.user.has_group(
+            "base.group_system"
+        ):
+            sudo_self = self.sudo()
+        return super(BaseAutomation, sudo_self)._update_cron()

--- a/container_accessibility/models/ir_actions_server.py
+++ b/container_accessibility/models/ir_actions_server.py
@@ -1,0 +1,79 @@
+from odoo import api, fields, models
+
+# Move constants into a mapping for cleaner iteration
+MODULE_STATE_MAPPING = {
+    "mail": [
+        ("next_activity", "Create Activity"),
+        ("mail_post", "Send Email"),
+        ("followers", "Add Followers"),
+        ("remove_followers", "Remove Followers"),
+    ],
+    "server_action_mass_edit": [("mass_edit", "Mass Edit Records")],
+    "sms": [("sms", "Send SMS")],
+}
+
+STATE_CHOICES_BASE = [
+    ("object_write", "Update Record"),
+    ("object_create", "Create Record"),
+    ("code", "Execute Code"),
+    ("webhook", "Send Webhook Notification"),
+    ("multi", "Execute Existing Actions"),
+]
+
+
+class IrActionsServer(models.Model):
+    _inherit = "ir.actions.server"
+
+    @api.model
+    def _get_all_state_choices(self):
+        """Combines base choices with installed module choices, ensuring uniqueness."""
+        # Use a dict to automatically handle overrides/duplicates by key
+        choices_dict = dict(STATE_CHOICES_BASE)
+
+        # Filter for installed modules in one go
+        installed_modules = (
+            self.env["ir.module.module"]
+            .sudo()
+            .search(
+                [
+                    ("name", "in", list(MODULE_STATE_MAPPING.keys())),
+                    ("state", "=", "installed"),
+                ]
+            )
+            .mapped("name")
+        )
+
+        for module in installed_modules:
+            choices_dict.update(dict(MODULE_STATE_MAPPING[module]))
+
+        return list(choices_dict.items())
+
+    @api.model
+    def _get_groups_to_restrict_state_choices(self):
+        """Hook to add groups to remove choices.
+        :type : list
+        """
+        return ["container_accessibility.group_restricted"]
+
+    @api.model
+    def _get_state_choices_to_restrict(self):
+        """Hook to add choices to remove.
+        :type : list
+        """
+        # We only need the keys (the first element of the tuples) to filter effectively
+        return ["code"]
+
+    @api.model
+    def _get_state_selection_choices(self):
+        """Returns the filtered selection list based on user groups."""
+        choices = self._get_all_state_choices()
+        if any(
+            self.env.user.has_group(group_xml_id)
+            for group_xml_id in self._get_groups_to_restrict_state_choices()
+        ):
+            to_restrict = self._get_state_choices_to_restrict()
+            return [c for c in choices if c[0] not in to_restrict]
+
+        return choices
+
+    state = fields.Selection(selection=lambda self: self._get_state_selection_choices())


### PR DESCRIPTION
This PR addresses access control issues and UI refinements for users within the "Restricted" group, specifically focusing on their ability to manage and interact with Automation Rules and Server Actions.

**_Issues Resolved:_**

1. Permission Denial: Restricted users were previously blocked from creating Automation rules.
2. Unauthorized Selections: Restricted users could view and select unauthorized options in the Trigger field (Automation Rules) and the State/Type field (Server Actions).
3. Menu Visibility: The "Automation" menu was hidden from the Restricted user group.

**_Core Solution_**
1. Bypassing Restriction Mixins: During CRUD operations on base.automation, the system calls _update_cron, which triggers _check_restrict via container.restrict.mixin.

Optimization: We modified the logic to execute the environment with Sudo access when specific conditions are met, ensuring the restricted user can complete the action without a permission error.

2. Dynamic Selection Filtering: Overrode the selection fields for Trigger (base_automation) and State (ir.actions.server).
Implemented dynamic hook functions to programmatically filter and display only authorized choices based on the user's group.

3) UI & Dependency Updates: Adjusted XML menu definitions to grant visibility of the Automation menu to the Restricted Group.

**_Query :_** 

1. Should we restrict  **Send Webhook Notification** from **Server Action**?