### PR TITLE
[FIX] container_accessibility: Fix for access issue coming up for "ir…

### DIFF
--- a/container_accessibility/__manifest__.py
+++ b/container_accessibility/__manifest__.py
@@ -7,6 +7,7 @@
     "depends": [
         "base",
         "base_setup",
+        "base_automation",
         "mail",
         "privacy_lookup",
         "web_tour",

--- a/container_accessibility/menuitems.xml
+++ b/container_accessibility/menuitems.xml
@@ -16,7 +16,11 @@
         <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
     </record>
 
-    <record id="base.menu_automation" model="ir.ui.menu">
+    <record id="base.menu_ir_cron_act" model="ir.ui.menu">
+        <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
+    </record>
+
+    <record id="base.ir_cron_trigger_menu" model="ir.ui.menu">
         <field name="excluded_group_ids" eval="[Command.link(ref('container_accessibility.group_restricted'))]"/>
     </record>
 

--- a/container_accessibility/models/__init__.py
+++ b/container_accessibility/models/__init__.py
@@ -15,3 +15,5 @@ from . import server_config
 from . import fetchmail_server
 from . import ir_config_parameter
 from . import discuss_channel
+from . import base_automation
+from . import ir_actions_server

--- a/container_accessibility/models/base_automation.py
+++ b/container_accessibility/models/base_automation.py
@@ -1,0 +1,73 @@
+from odoo import api, models
+from odoo.exceptions import AccessError
+
+
+class BaseAutomation(models.Model):
+    _inherit = "base.automation"
+
+    @api.model
+    def _get_groups_to_restrict_trigger_choices(self):
+        """Hook to add groups to restrict choices.
+        :type : list
+        """
+        return ["container_accessibility.group_restricted"]
+
+    @api.model
+    def _get_trigger_choices_to_restrict(self):
+        """Hook to add choices to restrict.
+        :type : list
+        """
+        # We only need the keys (the first element of the tuples) to filter effectively
+        return ["on_create_or_write", "on_unlink", "on_change", "on_webhook"]
+
+    @api.constrains("trigger")
+    def _check_trigger_choice_selection(self):
+        for record in self:
+            if (
+                any(
+                    self.env.user.has_group(xml_id)
+                    for xml_id in self._get_groups_to_restrict_trigger_choices()
+                )
+                and record.trigger in self._get_trigger_choices_to_restrict()
+            ):
+                human_readable_selection_string = self._fields[
+                    "trigger"
+                ].convert_to_export(record.trigger, self)
+                raise AccessError(
+                    self.env._(
+                        f"Sorry, You are restricted to use '{human_readable_selection_string}' Trigger ! \n Please contact your system administrator."
+                    )
+                )
+
+    @api.model
+    def _get_trigger_selection_choices(self):
+        """Returns the filtered selection list."""
+        trigger_choices = self._fields["trigger"]._description_selection(self.env)
+        if any(
+            self.env.user.has_group(xml_id)
+            for xml_id in self._get_groups_to_restrict_trigger_choices()
+        ):
+            to_restrict = self._get_trigger_choices_to_restrict()
+            # Filter the list by checking if the key (item[0]) is in our removal set
+            return [
+                choice for choice in trigger_choices if choice[0] not in to_restrict
+            ]
+
+        return trigger_choices
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        """Filter selection options based on user group."""
+        res = super().fields_get(allfields, attributes)
+        # Check if 'trigger' is in the returned fields
+        if "trigger" in res:
+            res["trigger"]["selection"] = self._get_trigger_selection_choices()
+        return res
+
+    def _update_cron(self):
+        sudo_self = self
+        if self.env.user.is_restricted_user() and self.env.user.has_group(
+            "base.group_system"
+        ):
+            sudo_self = self.sudo()
+        return super(BaseAutomation, sudo_self)._update_cron()

--- a/container_accessibility/models/ir_actions_server.py
+++ b/container_accessibility/models/ir_actions_server.py
@@ -1,0 +1,62 @@
+from odoo import api, models
+from odoo.exceptions import AccessError
+
+
+class IrActionsServer(models.Model):
+    _inherit = "ir.actions.server"
+
+    @api.model
+    def _get_groups_to_restrict_state_choices(self):
+        """Hook to add groups to remove choices.
+        :type : list
+        """
+        return ["container_accessibility.group_restricted"]
+
+    @api.model
+    def _get_state_choices_to_restrict(self):
+        """Hook to add choices to remove.
+        :type : list
+        """
+        # We only need the keys (the first element of the tuples) to filter effectively
+        return ["code"]
+
+    @api.constrains("state")
+    def _check_trigger_state_selection(self):
+        for record in self:
+            if (
+                any(
+                    self.env.user.has_group(xml_id)
+                    for xml_id in self._get_groups_to_restrict_state_choices()
+                )
+                and record.state in self._get_state_choices_to_restrict()
+            ):
+                human_readable_selection_string = self._fields[
+                    "state"
+                ].convert_to_export(record.state, self)
+                raise AccessError(
+                    self.env._(
+                        f"Sorry, You are restricted to use '{human_readable_selection_string}' Type of Server Action! Please contact your system administrator."
+                    )
+                )
+
+    @api.model
+    def _get_state_selection_choices(self):
+        """Returns the filtered selection list based on user groups."""
+        choices = self._fields["state"]._description_selection(self.env)
+        if any(
+            self.env.user.has_group(group_xml_id)
+            for group_xml_id in self._get_groups_to_restrict_state_choices()
+        ):
+            to_restrict = self._get_state_choices_to_restrict()
+            return [c for c in choices if c[0] not in to_restrict]
+
+        return choices
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        """Filter selection options based on user group."""
+        res = super().fields_get(allfields, attributes)
+        # Check if 'state' is in the returned fields
+        if "state" in res:
+            res["state"]["selection"] = self._get_state_selection_choices()
+        return res

--- a/container_accessibility/models/restrict_mixin.py
+++ b/container_accessibility/models/restrict_mixin.py
@@ -56,6 +56,10 @@ class ActionsActions(models.Model):
     _name = "ir.actions.actions"
     _inherit = ["ir.actions.actions", "container.restrict.mixin"]
 
+    @api.model
+    def _get_restrict_domain(self):
+        return [("base_automation_id", "!=", False)]
+
 
 class IrCron(models.Model):
     _name = "ir.cron"

--- a/container_accessibility/security/ir_rule.xml
+++ b/container_accessibility/security/ir_rule.xml
@@ -155,7 +155,7 @@
     <record id="rule_restricted_ir_actions_server" model="ir.rule">
         <field name="name">rule_restricted_ir_actions_server</field>
         <field name="model_id" ref="base.model_ir_actions_server"/>
-        <field name="domain_force">[('id', '=', False)]</field>
+        <field name="domain_force">[('base_automation_id', '!=', False)]</field>
         <field name="perm_read" eval="0"/>
         <field name="perm_create" eval="1"/>
         <field name="perm_write" eval="1"/>

--- a/container_accessibility/tests/__init__.py
+++ b/container_accessibility/tests/__init__.py
@@ -1,2 +1,4 @@
 from . import test_oauth
 from . import test_user_limit
+from . import test_base_automations
+from . import test_ir_actions_server

--- a/container_accessibility/tests/test_base_automations.py
+++ b/container_accessibility/tests/test_base_automations.py
@@ -1,0 +1,373 @@
+from unittest.mock import patch
+from odoo.tests import tagged
+from odoo.exceptions import AccessError
+from odoo.tests.common import TransactionCase
+
+
+class TestBaseAutomation(TransactionCase):
+    """Test suite for container_accessibility.BaseAutomation overrides.
+
+    Covers all five methods:
+      1. _get_groups_to_restrict_trigger_choices
+      2. _get_trigger_choices_to_restrict
+      3. _check_trigger_choice_selection  (constrains)
+      4. _get_trigger_selection_choices
+      5. fields_get
+      6. _update_cron
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Grab a partner model to use as the base-automation model target
+        cls.partner_model = cls.env.ref("base.model_res_partner")
+
+        # Restricted group
+        cls.group_restricted = cls.env.ref(
+            "container_accessibility.group_restricted"
+        )
+
+        # Create a restricted user (has group_restricted + group_system so he
+        # can still write base.automation records)
+        cls.restricted_user = cls.env["res.users"].create(
+            {
+                "name": "Restricted Tester",
+                "login": "restricted_tester_ba@test.local",
+                "groups_id": [
+                    (4, cls.env.ref("base.group_system").id),
+                    (4, cls.group_restricted.id),
+                ],
+            }
+        )
+
+        # A plain admin (super-user; does NOT have group_restricted)
+        cls.admin_user = cls.env.ref("base.user_admin")
+
+        # Minimal automation record created as admin – trigger "on_time" is
+        # never restricted, so it always passes the constrains check.
+        cls.automation = cls.env["base.automation"].create(
+            {
+                "name": "Test Automation",
+                "model_id": cls.partner_model.id,
+                "trigger": "on_time",
+            }
+        )
+
+    # ------------------------------------------------------------------ #
+    # 1. _get_groups_to_restrict_trigger_choices                           #
+    # ------------------------------------------------------------------ #
+
+    @tagged('post_install','-at_install')
+    def test_get_groups_to_restrict_returns_list(self):
+        """Return value must be a non-empty list."""
+        result = self.env["base.automation"]._get_groups_to_restrict_trigger_choices()
+        self.assertIsInstance(result, list)
+        self.assertTrue(result, "Expected at least one group xml_id in the list")
+
+    @tagged('post_install','-at_install')
+    def test_get_groups_to_restrict_contains_expected_group(self):
+        """The restricted group xml_id must be present."""
+        result = self.env["base.automation"]._get_groups_to_restrict_trigger_choices()
+        self.assertIn("container_accessibility.group_restricted", result)
+
+    # ------------------------------------------------------------------ #
+    # 2. _get_trigger_choices_to_restrict                                  #
+    # ------------------------------------------------------------------ #
+    @tagged('post_install','-at_install')
+    def test_get_trigger_choices_to_restrict_returns_list(self):
+        result = self.env["base.automation"]._get_trigger_choices_to_restrict()
+        self.assertIsInstance(result, list)
+        self.assertTrue(result)
+
+    @tagged('post_install','-at_install')
+    def test_get_trigger_choices_to_restrict_expected_values(self):
+        expected = {"on_create_or_write", "on_unlink", "on_change", "on_webhook"}
+        result = set(self.env["base.automation"]._get_trigger_choices_to_restrict())
+        self.assertEqual(result, expected)
+
+    # ------------------------------------------------------------------ #
+    # 3. _check_trigger_choice_selection (constrains)                      #
+    # ------------------------------------------------------------------ #
+
+    @tagged('post_install','-at_install')
+    def test_constrains_raises_for_restricted_user_with_restricted_trigger(self):
+        """A restricted user must NOT be able to set a restricted trigger."""
+        env_restricted = self.env["base.automation"].with_user(self.restricted_user)
+        for trigger in ["on_create_or_write", "on_unlink", "on_change", "on_webhook"]:
+            with self.subTest(trigger=trigger):
+                with self.assertRaises(AccessError):
+                    env_restricted.create(
+                        {
+                            "name": f"Bad Automation ({trigger})",
+                            "model_id": self.partner_model.id,
+                            "trigger": trigger,
+                        }
+                    )
+
+    
+    @tagged('post_install','-at_install')
+    def test_constrains_passes_for_restricted_user_with_allowed_trigger(self):
+        """A restricted user CAN set a trigger that is not in the restricted list."""
+        env_restricted = self.env["base.automation"].with_user(self.restricted_user)
+        # "on_time" is not in the restricted set
+        record = env_restricted.create(
+            {
+                "name": "Allowed Automation (on_time)",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+            }
+        )
+        self.assertTrue(record.exists())
+
+    @tagged('post_install','-at_install')
+    def test_constrains_passes_for_admin_with_restricted_trigger(self):
+        """An admin user (not in group_restricted) can use any trigger freely."""
+        env_admin = self.env["base.automation"].with_user(self.admin_user)
+        record = env_admin.create(
+            {
+                "name": "Admin Automation (on_create_or_write)",
+                "model_id": self.partner_model.id,
+                "trigger": "on_create_or_write",
+            }
+        )
+        self.assertTrue(record.exists())
+
+    @tagged('post_install','-at_install')
+    def test_constrains_raises_on_write_for_restricted_user(self):
+        """Writing a restricted trigger on an existing record should also raise."""
+        # Create with an allowed trigger as admin first
+        record = self.env["base.automation"].create(
+            {
+                "name": "Automation for write test",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+            }
+        )
+        env_restricted = record.with_user(self.restricted_user)
+        with self.assertRaises(AccessError):
+            env_restricted.write({"trigger": "on_unlink"})
+
+    @tagged('post_install','-at_install')
+    def test_constrains_passes_on_write_with_allowed_trigger_for_restricted_user(self):
+        """Writing an allowed trigger on an existing record must succeed."""
+        record = self.env["base.automation"].create(
+            {
+                "name": "Automation for allowed write test",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+            }
+        )
+        env_restricted = record.with_user(self.restricted_user)
+        # "on_time" is not restricted – staying on it (or updating name) must be fine
+        env_restricted.write({"name": "Updated Name"})
+        self.assertEqual(record.name, "Updated Name")
+
+    # ------------------------------------------------------------------ #
+    # 4. _get_trigger_selection_choices                                    #
+    # ------------------------------------------------------------------ #
+
+    @tagged('post_install','-at_install')
+    def test_selection_choices_filtered_for_restricted_user(self):
+        """Restricted user must not see the restricted trigger choices."""
+        env_restricted = self.env["base.automation"].with_user(self.restricted_user)
+        choices = env_restricted._get_trigger_selection_choices()
+        restricted_keys = env_restricted._get_trigger_choices_to_restrict()
+        returned_keys = [c[0] for c in choices]
+        for key in restricted_keys:
+            with self.subTest(key=key):
+                self.assertNotIn(key, returned_keys)
+
+    @tagged('post_install','-at_install')
+    def test_selection_choices_not_filtered_for_admin(self):
+        """Admin user must see the full (unfiltered) trigger choices list."""
+        env_admin = self.env["base.automation"].with_user(self.admin_user)
+        all_choices = env_admin._fields["trigger"]._description_selection(env_admin.env)
+        filtered_choices = env_admin._get_trigger_selection_choices()
+        # Admin is not in group_restricted so both lists must be identical
+        self.assertEqual(all_choices, filtered_choices)
+
+    @tagged('post_install','-at_install')
+    def test_selection_choices_returns_list_of_tuples(self):
+        """Each element of the returned choices must be a 2-tuple."""
+        choices = self.env["base.automation"]._get_trigger_selection_choices()
+        self.assertIsInstance(choices, list)
+        for item in choices:
+            with self.subTest(item=item):
+                self.assertIsInstance(item, tuple)
+                self.assertEqual(len(item), 2)
+
+    @tagged('post_install','-at_install')
+    def test_selection_choices_restricted_user_still_has_allowed_triggers(self):
+        """Restricted user must still see triggers that are NOT restricted."""
+        env_restricted = self.env["base.automation"].with_user(self.restricted_user)
+        choices = env_restricted._get_trigger_selection_choices()
+        restricted_keys = set(env_restricted._get_trigger_choices_to_restrict())
+        returned_keys = {c[0] for c in choices}
+        allowed_keys = returned_keys - restricted_keys
+        # There should be at least some allowed triggers remaining
+        self.assertTrue(
+            allowed_keys,
+            "Restricted user should still have some non-restricted trigger options",
+        )
+
+    # ------------------------------------------------------------------ #
+    # 5. fields_get                                                        #
+    # ------------------------------------------------------------------ #
+
+    @tagged('post_install','-at_install')
+    def test_fields_get_trigger_selection_filtered_for_restricted_user(self):
+        """fields_get must inject the filtered trigger selection for restricted users."""
+        env_restricted = self.env["base.automation"].with_user(self.restricted_user)
+        result = env_restricted.fields_get(allfields=["trigger"])
+        self.assertIn("trigger", result)
+        selection_keys = [s[0] for s in result["trigger"]["selection"]]
+        restricted_keys = env_restricted._get_trigger_choices_to_restrict()
+        for key in restricted_keys:
+            with self.subTest(key=key):
+                self.assertNotIn(key, selection_keys)
+
+    @tagged('post_install','-at_install')
+    def test_fields_get_trigger_selection_unfiltered_for_admin(self):
+        """fields_get must return the full trigger selection for admin users."""
+        env_admin = self.env["base.automation"].with_user(self.admin_user)
+        result = env_admin.fields_get(allfields=["trigger"])
+        self.assertIn("trigger", result)
+        # All trigger values should be present (nothing removed for admin)
+        all_choices = env_admin._fields["trigger"]._description_selection(env_admin.env)
+        self.assertEqual(result["trigger"]["selection"], all_choices)
+
+    @tagged('post_install','-at_install')
+    def test_fields_get_without_trigger_field_request(self):
+        """fields_get must still work when 'trigger' is not requested."""
+        env_admin = self.env["base.automation"].with_user(self.admin_user)
+        result = env_admin.fields_get(allfields=["name"])
+        # 'trigger' not requested → it should not appear in the result
+        self.assertNotIn("trigger", result)
+        self.assertIn("name", result)
+
+    @tagged('post_install','-at_install')
+    def test_fields_get_all_fields_does_not_break(self):
+        """Calling fields_get with no field filter (all fields) must not raise."""
+        env_restricted = self.env["base.automation"].with_user(self.restricted_user)
+        try:
+            result = env_restricted.fields_get()
+        except Exception as exc:  # noqa: BLE001
+            self.fail(f"fields_get() raised unexpectedly: {exc}")
+        self.assertIn("trigger", result)
+
+    # ------------------------------------------------------------------ #
+    # 6. _update_cron                                                      #
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def _find_parent_update_cron_class(cls, record):
+        """Traverse the registry MRO to find the first ancestor class that defines
+        _update_cron, skipping container_accessibility's own override.
+        Returns (parent_class, original_method) or (None, None)."""
+        our_module = "odoo.addons.container_accessibility.models.base_automation"
+        for klass in type(record).__mro__:
+            if klass.__module__ != our_module and "_update_cron" in klass.__dict__:
+                return klass, klass.__dict__["_update_cron"]
+        return None, None
+
+    @tagged('post_install', '-at_install')
+    def test_update_cron_uses_sudo_for_restricted_system_user(self):
+        """_update_cron must forward to super() with a sudo() self when the
+        current user is both restricted (group_restricted) and a system admin."""
+        record = self.env["base.automation"].create(
+            {
+                "name": "Cron Automation",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+            }
+        )
+        env_restricted = record.with_user(self.restricted_user)
+
+        parent_class, _ = self._find_parent_update_cron_class(env_restricted)
+        if parent_class is None:
+            self.skipTest("Could not locate parent _update_cron in the MRO")
+
+        calls = []
+
+        # Patch the actual parent class in the registry MRO so that super()
+        # dispatch inside our override routes to our spy correctly.
+        with patch.object(parent_class, "_update_cron", lambda self_arg: calls.append(self_arg)):
+            env_restricted._update_cron()
+
+        self.assertTrue(calls, "_update_cron was never forwarded to the parent class")
+        called_self = calls[0]
+        # sudo() sets env.su = True on the recordset it returns.
+        self.assertTrue(
+            called_self.env.su,
+            "Expected env.su=True (sudo context) when a restricted+system user "
+            "calls _update_cron",
+        )
+
+    @tagged('post_install', '-at_install')
+    def test_update_cron_does_not_sudo_for_plain_admin(self):
+        """_update_cron must NOT elevate to sudo for a plain admin (not restricted)."""
+        record = self.env["base.automation"].create(
+            {
+                "name": "Cron Automation Admin",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+            }
+        )
+        env_admin = record.with_user(self.admin_user)
+
+        parent_class, _ = self._find_parent_update_cron_class(env_admin)
+        if parent_class is None:
+            self.skipTest("Could not locate parent _update_cron in the MRO")
+
+        calls = []
+
+        with patch.object(parent_class, "_update_cron", lambda self_arg: calls.append(self_arg)):
+            env_admin._update_cron()
+
+        self.assertTrue(calls)
+        called_self = calls[0]
+        # Admin is not restricted → sudo() must NOT have been called.
+        self.assertFalse(
+            called_self.env.su,
+            "Plain admin should not be escalated to sudo in _update_cron",
+        )
+
+    @tagged('post_install', '-at_install')
+    def test_update_cron_does_not_sudo_for_restricted_user_without_system_group(self):
+        """A restricted user WITHOUT group_system must not have cron calls elevated."""
+        restricted_only_user = self.env["res.users"].create(
+            {
+                "name": "Restricted No System",
+                "login": "restricted_no_sys@test.local",
+                "groups_id": [
+                    (4, self.env.ref("base.group_user").id),
+                    (4, self.group_restricted.id),
+                ],
+            }
+        )
+        record = self.env["base.automation"].create(
+            {
+                "name": "Cron Automation Restricted Only",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+            }
+        )
+        env_restricted_only = record.with_user(restricted_only_user)
+
+        parent_class, _ = self._find_parent_update_cron_class(env_restricted_only)
+        if parent_class is None:
+            self.skipTest("Could not locate parent _update_cron in the MRO")
+
+        calls = []
+
+        with patch.object(parent_class, "_update_cron", lambda self_arg: calls.append(self_arg)):
+            env_restricted_only._update_cron()
+
+        self.assertTrue(calls)
+        called_self = calls[0]
+        # Restricted without group_system → condition is False → no sudo.
+        self.assertFalse(
+            called_self.env.su,
+            "Restricted user without group_system should not be escalated in _update_cron",
+        )

--- a/container_accessibility/tests/test_ir_actions_server.py
+++ b/container_accessibility/tests/test_ir_actions_server.py
@@ -1,0 +1,382 @@
+from odoo.tests import tagged
+from odoo.exceptions import AccessError
+from odoo.tests.common import TransactionCase
+
+
+class TestIrActionsServer(TransactionCase):
+    """Test suite for container_accessibility.IrActionsServer overrides.
+
+    Covers all four methods:
+      1. _get_groups_to_restrict_state_choices
+      2. _get_state_choices_to_restrict
+      3. _check_trigger_state_selection  (constrains)
+      4. _get_state_selection_choices
+      5. fields_get
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Restricted group
+        cls.group_restricted = cls.env.ref(
+            "container_accessibility.group_restricted"
+        )
+
+        # Create a restricted user (has group_restricted + group_system so he
+        # can still write ir.actions.server records)
+        cls.restricted_user = cls.env["res.users"].create(
+            {
+                "name": "Restricted Server Action Tester",
+                "login": "restricted_tester_ias@test.local",
+                "groups_id": [
+                    (4, cls.env.ref("base.group_system").id),
+                    (4, cls.group_restricted.id),
+                ],
+            }
+        )
+
+        # A plain admin (super-user; does NOT have group_restricted)
+        cls.admin_user = cls.env.ref("base.user_admin")
+
+        # Grab a model to use as the server-action model target
+        cls.partner_model = cls.env.ref("base.model_res_partner")
+
+    # ------------------------------------------------------------------ #
+    # 1. _get_groups_to_restrict_state_choices                            #
+    # ------------------------------------------------------------------ #
+
+    @tagged("post_install", "-at_install")
+    def test_get_groups_to_restrict_returns_list(self):
+        """Return value must be a non-empty list."""
+        result = self.env[
+            "ir.actions.server"
+        ]._get_groups_to_restrict_state_choices()
+        self.assertIsInstance(result, list)
+        self.assertTrue(result, "Expected at least one group xml_id in the list")
+
+    @tagged("post_install", "-at_install")
+    def test_get_groups_to_restrict_contains_expected_group(self):
+        """The restricted group xml_id must be present in the list."""
+        result = self.env[
+            "ir.actions.server"
+        ]._get_groups_to_restrict_state_choices()
+        self.assertIn("container_accessibility.group_restricted", result)
+
+    # ------------------------------------------------------------------ #
+    # 2. _get_state_choices_to_restrict                                   #
+    # ------------------------------------------------------------------ #
+
+    @tagged("post_install", "-at_install")
+    def test_get_state_choices_to_restrict_returns_list(self):
+        """Return value must be a non-empty list."""
+        result = self.env["ir.actions.server"]._get_state_choices_to_restrict()
+        self.assertIsInstance(result, list)
+        self.assertTrue(result)
+
+    @tagged("post_install", "-at_install")
+    def test_get_state_choices_to_restrict_expected_values(self):
+        """'code' must be the restricted state choice."""
+        result = self.env["ir.actions.server"]._get_state_choices_to_restrict()
+        self.assertIn("code", result)
+
+    # ------------------------------------------------------------------ #
+    # 3. _check_trigger_state_selection (constrains)                      #
+    # ------------------------------------------------------------------ #
+
+    @tagged("post_install", "-at_install")
+    def test_constrains_raises_for_restricted_user_with_code_state(self):
+        """A restricted user must NOT be able to create a server action with state='code'."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        with self.assertRaises(AccessError):
+            env_restricted.create(
+                {
+                    "name": "Bad Server Action (code)",
+                    "model_id": self.partner_model.id,
+                    "state": "code",
+                }
+            )
+
+    @tagged("post_install", "-at_install")
+    def test_constrains_passes_for_restricted_user_with_allowed_state(self):
+        """A restricted user CAN create a server action with a non-restricted state,
+        provided it is linked to a base.automation (required by restrict_mixin domain)."""
+        # Create the server action as admin first so it exists without restriction
+        server_action = self.env["ir.actions.server"].create(
+            {
+                "name": "Allowed Server Action (object_write)",
+                "model_id": self.partner_model.id,
+                "state": "object_write",
+            }
+        )
+        # Link it to a base.automation so restrict_mixin domain
+        # [("base_automation_id", "!=", False)] is satisfied
+        self.env["base.automation"].create(
+            {
+                "name": "Automation for allowed state test",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+                "action_server_ids": [(4, server_action.id)],
+            }
+        )
+        # Now a restricted user can write to it (non-restricted state → no AccessError)
+        env_restricted = server_action.with_user(self.restricted_user)
+        env_restricted.write({"name": "Allowed Server Action (object_write) - updated"})
+        self.assertTrue(server_action.exists())
+
+    @tagged("post_install", "-at_install")
+    def test_constrains_passes_for_admin_with_code_state(self):
+        """An admin user (not in group_restricted) can use the 'code' state freely."""
+        env_admin = self.env["ir.actions.server"].with_user(self.admin_user)
+        record = env_admin.create(
+            {
+                "name": "Admin Server Action (code)",
+                "model_id": self.partner_model.id,
+                "state": "code",
+                "code": "record.write({})",
+            }
+        )
+        self.assertTrue(record.exists())
+
+    @tagged("post_install", "-at_install")
+    def test_constrains_raises_on_write_for_restricted_user(self):
+        """Writing state='code' on an existing record as a restricted user must raise."""
+        # Create with an allowed state as admin
+        record = self.env["ir.actions.server"].create(
+            {
+                "name": "Server Action for write test",
+                "model_id": self.partner_model.id,
+                "state": "object_write",
+            }
+        )
+        # Link to a base.automation so the restrict_mixin domain is satisfied
+        # and the restricted user can reach the constrains check
+        self.env["base.automation"].create(
+            {
+                "name": "Automation for write test",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+                "action_server_ids": [(4, record.id)],
+            }
+        )
+        env_restricted = record.with_user(self.restricted_user)
+        with self.assertRaises(AccessError):
+            env_restricted.write({"state": "code"})
+
+    @tagged("post_install", "-at_install")
+    def test_constrains_passes_on_write_with_allowed_state_for_restricted_user(self):
+        """Writing an allowed (non-restricted) state on a linked record must succeed."""
+        record = self.env["ir.actions.server"].create(
+            {
+                "name": "Server Action for allowed write test",
+                "model_id": self.partner_model.id,
+                "state": "object_write",
+            }
+        )
+        # Link to a base.automation so the restrict_mixin domain is satisfied
+        self.env["base.automation"].create(
+            {
+                "name": "Automation for allowed write test",
+                "model_id": self.partner_model.id,
+                "trigger": "on_time",
+                "action_server_ids": [(4, record.id)],
+            }
+        )
+        env_restricted = record.with_user(self.restricted_user)
+        # Updating the name while staying on a non-restricted state must be fine
+        env_restricted.write({"name": "Updated Server Action Name"})
+        self.assertEqual(record.name, "Updated Server Action Name")
+
+    @tagged("post_install", "-at_install")
+    def test_constrains_error_message_contains_human_readable_state(self):
+        """The AccessError message must mention the human-readable label of the state."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        try:
+            env_restricted.create(
+                {
+                    "name": "Error Message Test",
+                    "model_id": self.partner_model.id,
+                    "state": "code",
+                }
+            )
+            self.fail("AccessError was not raised")
+        except AccessError as exc:
+            self.assertIn(
+                "restricted",
+                str(exc).lower(),
+                "Error message should mention restriction",
+            )
+
+    # ------------------------------------------------------------------ #
+    # 4. _get_state_selection_choices                                     #
+    # ------------------------------------------------------------------ #
+
+    @tagged("post_install", "-at_install")
+    def test_state_selection_choices_filtered_for_restricted_user(self):
+        """Restricted user must not see the restricted state choices."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        choices = env_restricted._get_state_selection_choices()
+        restricted_keys = env_restricted._get_state_choices_to_restrict()
+        returned_keys = [c[0] for c in choices]
+        for key in restricted_keys:
+            with self.subTest(key=key):
+                self.assertNotIn(key, returned_keys)
+
+    @tagged("post_install", "-at_install")
+    def test_state_selection_choices_not_filtered_for_admin(self):
+        """Admin user must see the full (unfiltered) state choices list."""
+        env_admin = self.env["ir.actions.server"].with_user(self.admin_user)
+        all_choices = env_admin._fields["state"]._description_selection(
+            env_admin.env
+        )
+        filtered_choices = env_admin._get_state_selection_choices()
+        # Admin is not in group_restricted so both lists must be identical
+        self.assertEqual(all_choices, filtered_choices)
+
+    @tagged("post_install", "-at_install")
+    def test_state_selection_choices_returns_list_of_tuples(self):
+        """Each element of the returned choices must be a 2-tuple."""
+        choices = self.env["ir.actions.server"]._get_state_selection_choices()
+        self.assertIsInstance(choices, list)
+        for item in choices:
+            with self.subTest(item=item):
+                self.assertIsInstance(item, tuple)
+                self.assertEqual(len(item), 2)
+
+    @tagged("post_install", "-at_install")
+    def test_state_selection_choices_restricted_user_still_has_allowed_states(self):
+        """Restricted user must still see states that are NOT restricted."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        choices = env_restricted._get_state_selection_choices()
+        restricted_keys = set(env_restricted._get_state_choices_to_restrict())
+        returned_keys = {c[0] for c in choices}
+        allowed_keys = returned_keys - restricted_keys
+        self.assertTrue(
+            allowed_keys,
+            "Restricted user should still have some non-restricted state options",
+        )
+
+    @tagged("post_install", "-at_install")
+    def test_state_selection_choices_code_absent_for_restricted_user(self):
+        """'code' state must specifically be absent for a restricted user."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        choices = env_restricted._get_state_selection_choices()
+        returned_keys = [c[0] for c in choices]
+        self.assertNotIn(
+            "code",
+            returned_keys,
+            "Restricted user must not see 'code' in state selection choices",
+        )
+
+    @tagged("post_install", "-at_install")
+    def test_state_selection_choices_code_present_for_admin(self):
+        """'code' state must be present for an admin user."""
+        env_admin = self.env["ir.actions.server"].with_user(self.admin_user)
+        choices = env_admin._get_state_selection_choices()
+        returned_keys = [c[0] for c in choices]
+        self.assertIn(
+            "code",
+            returned_keys,
+            "Admin must see 'code' in state selection choices",
+        )
+
+    # ------------------------------------------------------------------ #
+    # 5. fields_get                                                        #
+    # ------------------------------------------------------------------ #
+
+    @tagged("post_install", "-at_install")
+    def test_fields_get_state_selection_filtered_for_restricted_user(self):
+        """fields_get must inject the filtered state selection for restricted users."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        result = env_restricted.fields_get(allfields=["state"])
+        self.assertIn("state", result)
+        selection_keys = [s[0] for s in result["state"]["selection"]]
+        restricted_keys = env_restricted._get_state_choices_to_restrict()
+        for key in restricted_keys:
+            with self.subTest(key=key):
+                self.assertNotIn(key, selection_keys)
+
+    @tagged("post_install", "-at_install")
+    def test_fields_get_state_selection_unfiltered_for_admin(self):
+        """fields_get must return the full state selection for admin users."""
+        env_admin = self.env["ir.actions.server"].with_user(self.admin_user)
+        result = env_admin.fields_get(allfields=["state"])
+        self.assertIn("state", result)
+        all_choices = env_admin._fields["state"]._description_selection(
+            env_admin.env
+        )
+        self.assertEqual(result["state"]["selection"], all_choices)
+
+    @tagged("post_install", "-at_install")
+    def test_fields_get_without_state_field_request(self):
+        """fields_get must still work when 'state' is not requested."""
+        env_admin = self.env["ir.actions.server"].with_user(self.admin_user)
+        result = env_admin.fields_get(allfields=["name"])
+        # 'state' not requested → it should not appear in the result
+        self.assertNotIn("state", result)
+        self.assertIn("name", result)
+
+    @tagged("post_install", "-at_install")
+    def test_fields_get_all_fields_does_not_break(self):
+        """Calling fields_get with no field filter (all fields) must not raise."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        try:
+            result = env_restricted.fields_get()
+        except Exception as exc:  # noqa: BLE001
+            self.fail(f"fields_get() raised unexpectedly: {exc}")
+        self.assertIn("state", result)
+
+    @tagged("post_install", "-at_install")
+    def test_fields_get_state_selection_is_list_of_tuples(self):
+        """The 'state' selection returned by fields_get must be a list of 2-tuples."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        result = env_restricted.fields_get(allfields=["state"])
+        self.assertIn("state", result)
+        selection = result["state"]["selection"]
+        self.assertIsInstance(selection, list)
+        for item in selection:
+            with self.subTest(item=item):
+                self.assertIsInstance(item, tuple)
+                self.assertEqual(len(item), 2)
+
+    @tagged("post_install", "-at_install")
+    def test_fields_get_code_absent_in_state_selection_for_restricted_user(self):
+        """fields_get must not include 'code' in the state selection for a restricted user."""
+        env_restricted = self.env["ir.actions.server"].with_user(
+            self.restricted_user
+        )
+        result = env_restricted.fields_get(allfields=["state"])
+        selection_keys = [s[0] for s in result["state"]["selection"]]
+        self.assertNotIn(
+            "code",
+            selection_keys,
+            "fields_get must exclude 'code' state for restricted user",
+        )
+
+    @tagged("post_install", "-at_install")
+    def test_fields_get_code_present_in_state_selection_for_admin(self):
+        """fields_get must include 'code' in the state selection for an admin user."""
+        env_admin = self.env["ir.actions.server"].with_user(self.admin_user)
+        result = env_admin.fields_get(allfields=["state"])
+        selection_keys = [s[0] for s in result["state"]["selection"]]
+        self.assertIn(
+            "code",
+            selection_keys,
+            "fields_get must include 'code' state for admin user",
+        )


### PR DESCRIPTION
This PR addresses access control issues and UI refinements for users within the "Restricted" group, specifically focusing on their ability to manage and interact with Automation Rules and Server Actions.

**_Issues Resolved:_**

1. Permission Denial: Restricted users were previously blocked from creating Automation rules.
2. Unauthorized Selections: Restricted users could view and select unauthorized options in the Trigger field (Automation Rules) and the State/Type field (Server Actions).
3. Menu Visibility: The "Automation" menu was hidden from the Restricted user group.

**_Core Solution_**
1. Bypassing Restriction Mixins: During CRUD operations on base.automation, the system calls _update_cron, which triggers _check_restrict via container.restrict.mixin.

Optimization: We modified the logic to execute the environment with Sudo access when specific conditions are met, ensuring the restricted user can complete the action without a permission error.

2. Dynamic Selection Filtering: Overrode orm method - "fields_get" to dynamicaly filter out choices of the fields for Trigger (base_automation) and State (ir.actions.server).
Implemented dynamic hook functions to programmatically filter and display only authorized choices based on the user's group.

3) UI & Dependency Updates: Adjusted XML menu definitions to grant visibility of the Automation menu to the Restricted Group.

**_Query :_** 

1. Should we restrict  **Send Webhook Notification** from **Server Action**?