### PR TITLE
Towncrier configuration and add release note features

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -13,6 +13,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Login to Docker
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: release
+name: tag
 
 on:
   push:
@@ -6,15 +6,6 @@ on:
       - "18.0.*.*"
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      major_tag: ${{ steps.vars.outputs.major_tag }}
-    steps:
-      - id: vars
-        run: |
-          echo "major_tag=$(echo '${{ github.ref_name }}' | sed 's/\.[^.]*$//')" >> "$GITHUB_OUTPUT"
-
   notify-start:
     runs-on: ubuntu-latest
     steps:
@@ -23,10 +14,36 @@ jobs:
           curl \
             -X POST https://api.telegram.org/bot${{ secrets.TELEGRAM_API_TOKEN }}/sendMessage \
             -H 'Content-Type: application/json' \
-            -d '{"chat_id":"${{ secrets.TELEGRAM_CHAT_ID }}","text":"📢 Release workflow started: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}", "parse_mode": "markdown"}' \
+            -d '{"chat_id":"${{ secrets.TELEGRAM_CHAT_ID }}","text":"📢 Testing tag `${{ github.ref_name }}`: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}", "parse_mode": "markdown"}' \
             --fail
+  
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      major_tag: ${{ steps.vars.outputs.major_tag }}
+    steps:
+      - id: vars
+        name: Extract major tag
+        run: |
+          echo "major_tag=$(echo '${{ github.ref_name }}' | sed 's/\.[^.]*$//')" >> "$GITHUB_OUTPUT"
+
+  check-dangling-news-fragments:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - name: Ensure no dangling newsfragments
+          run: |
+            # Count how many files are sitting in newsfragments (excluding .gitkeep)
+            FRAGMENT_COUNT=$(find newsfragments/ -type f ! -name ".gitkeep" | wc -l)
+            
+            if [ "$FRAGMENT_COUNT" -gt 0 ]; then
+              echo "❌ Found $FRAGMENT_COUNT uncompiled news fragments in newsfragments/."
+              echo "Did you forget to run 'towncrier build'?"
+              exit 1
+            fi
  
   build-ci:
+    needs: [check-dangling-news-fragments]
     uses: ./.github/workflows/build-and-push.yml
     with:
       tags: ghcr.io/${{ github.repository_owner }}/curq-ci:${{ github.ref_name }}
@@ -46,23 +63,6 @@ jobs:
       tags: ghcr.io/${{ github.repository_owner }}/curq:${{ github.ref_name }},ghcr.io/${{ github.repository_owner }}/curq:${{ needs.setup.outputs.major_tag }},ghcr.io/${{ github.repository_owner }}/curq:18.0
       target: base
 
-  release:
-    needs: [build]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
-          body: "/"
-          draft: false
-          prerelease: false
-
   tag-ci-latest:
     needs: [build]
     runs-on: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
           docker push ghcr.io/${{ github.repository_owner }}/curq-ci:18.0
 
   notify-failure:
-    needs: [build-ci, migration, build, release]
+    needs: [build-ci, migration, build]
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     steps:
@@ -90,5 +90,5 @@ jobs:
           curl \
             -X POST https://api.telegram.org/bot${{ secrets.TELEGRAM_API_TOKEN }}/sendMessage \
             -H 'Content-Type: application/json' \
-            -d '{"chat_id":"${{ secrets.TELEGRAM_CHAT_ID }}","text":"❤️‍🩹 Release workflow failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}", "parse_mode": "markdown"}' \
+            -d '{"chat_id":"${{ secrets.TELEGRAM_CHAT_ID }}","text":"❤️‍🩹 Testing tag `${{ github.ref_name }}` failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}", "parse_mode": "markdown"}' \
             --fail

--- a/.github/workflows/validate-newsfragment.yml
+++ b/.github/workflows/validate-newsfragment.yml
@@ -1,0 +1,28 @@
+name: validate-newsfragment
+on:
+  pull_request:
+    branches:
+      - "18.0"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Towncrier
+        run: |
+          pip3 install towncrier
+
+      - name: Validate added newsfragment
+        if: "!contains(github.event.pull_request.labels.*.name, 'no-newsfragment')"
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin 18.0:18.0
+          towncrier check --compare-with origin/18.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## News Fragments
+
+For every user-facing change, add a Towncrier news fragment.
+
+### When to add a fragment
+
+Add a fragment when your change affects what end users see or do, for example:
+
+- New functionality
+- Behavior changes or improvements
+- Bug fixes visible to users
+
+If a change is only internal and has no user impact, a fragment is not necessary.
+
+### Where to add it
+
+Create the file in `newsfragments/`.
+
+### File naming
+
+Use:
+
+`<identifier>.<type>.md`
+
+- Use the PR number when available, for example `123.fix.md`.
+- If there is no PR number, use any unique identifier, for example `+123.misc.md`.
+
+### Allowed types
+
+- `feat`
+- `imp`
+- `fix`
+- `misc`
+
+### Writing guidelines
+
+Write short, user-facing text (1 to 2 sentences) that explains the outcome for end users.
+
+- Focus on what changed for the user, not internal implementation details.
+- Keep wording clear and practical.
+- Avoid technical jargon or internal references.
+- Avoid markdown structures like headings, lists, or code blocks.
+
+Examples:
+
+- "Added automatic assignment of incoming payments to open invoices."
+- "Fixed duplicate contact suggestions when creating a sales order."
+
+Fragments are compiled into `NEWS.md` during the release process.

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY --parents \
 	resource_booking_install \
     spreadsheet_oca_ux \
 	partner_external_map_usability \
+	release_note \
 	./
 
 RUN apt-get install git -y
@@ -86,6 +87,7 @@ COPY --from=pack ./package /odoo/custom
 COPY --from=wheels ./wheels /odoo/wheels
 COPY --from=wheels /curq-requirements.txt /odoo/custom/requirements.txt
 COPY --from=wheels /requirements.txt /odoo/src/odoo/requirements.txt
+COPY ./NEWS.md /odoo/custom/NEWS.md
 COPY ./scripts /odoo/scripts
 RUN pip install --no-cache-dir -r /odoo/src/odoo/requirements.txt -r /odoo/custom/requirements.txt --find-links /odoo/wheels
 RUN pip install -e /odoo/src/odoo

--- a/package.txt
+++ b/package.txt
@@ -47,6 +47,7 @@ sales_team_update
 resource_booking_install
 spreadsheet_oca_ux
 partner_external_map_usability
+release_note
 addons-generic/account_journal_subtype
 addons-generic/account_partner_default_account
 addons-generic/account_period_auto_create

--- a/release_note/README.md
+++ b/release_note/README.md
@@ -1,0 +1,17 @@
+Shows a user-facing release note dialog after an update.
+
+This module automatically shows a popup with release notes when a user logs in
+after a new version has been deployed. Each user's last read version is tracked,
+so the popup only appears once per version.
+
+**towncrier integration**
+
+The module is designed to work with `towncrier
+<https://towncrier.readthedocs.io/>`_. Configure towncrier to produce Markdown
+output and commit the result as ``NEWS.md`` in the root of your repository.
+
+**Extending**
+
+Inherit ``release.note.wizard`` and override ``_get_release_notes()`` to
+retrieve the changelog from a different source, or ``_parse_release_notes()``
+to change the parsing logic.

--- a/release_note/__init__.py
+++ b/release_note/__init__.py
@@ -1,0 +1,2 @@
+from . import wizards
+from . import models

--- a/release_note/__manifest__.py
+++ b/release_note/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    "name": "Release Notes",
+    "author": "Onestein",
+    "website": "https://onestein.nl",
+    "category": "Extra Tools",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": ["web", "base_setup"],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizards/release_note_wizard_view.xml",
+        "views/res_config_settings_view.xml",
+        "templates/release_note.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "release_note/static/src/js/backend.esm.js",
+            "release_note/static/src/scss/backend.scss",
+        ],
+    },
+    "external_dependencies": {
+        "python": [
+            "markdown",
+        ],
+    },
+}

--- a/release_note/models/__init__.py
+++ b/release_note/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_users
+from . import res_config_settings

--- a/release_note/models/res_config_settings.py
+++ b/release_note/models/res_config_settings.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    release_note_version = fields.Char(
+        string="Current Version",
+        readonly=True,
+        config_parameter="release_note.current_version",
+    )
+    release_note_project = fields.Char(
+        readonly=True,
+        config_parameter="release_note.project",
+    )

--- a/release_note/models/res_users.py
+++ b/release_note/models/res_users.py
@@ -1,0 +1,24 @@
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _get_default_release_note_version(self):
+        # New users should have the current version as their last read version
+        # to avoid showing the release note wizard on their first login.
+
+        return (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("release_note.current_version")
+        )
+
+    last_release_note_version = fields.Char(
+        help="The last release note version that the user has read.",
+        default=lambda self: self._get_default_release_note_version(),
+        readonly=True,
+    )
+    has_unread_release_note = fields.Boolean(
+        readonly=True, help="Whether the user has unread release notes."
+    )

--- a/release_note/security/ir.model.access.csv
+++ b/release_note/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+release_note.access_release_note_wizard,access_release_note_wizard,release_note.model_release_note_wizard,base.group_user,1,1,1,1

--- a/release_note/static/src/js/backend.esm.js
+++ b/release_note/static/src/js/backend.esm.js
@@ -1,0 +1,33 @@
+import { WebClient } from "@web/webclient/webclient";
+import { onMounted } from "@odoo/owl";
+import { patch } from "@web/core/utils/patch";
+import { useService } from "@web/core/utils/hooks";
+
+
+
+patch(WebClient.prototype, {
+    setup() {
+        super.setup();
+        const actionService = useService("action");
+        const orm = useService("orm");
+
+        onMounted(async () => {
+            const releaseNoteAction = await orm.call(
+                "release.note.wizard", "action_open_release_notes"
+            );
+
+            if (!releaseNoteAction) {
+                return;
+            }
+
+            actionService.doAction(releaseNoteAction, {
+                onClose: async () => {
+                    await orm.call("release.note.wizard", "mark_release_notes_as_read");
+                    actionService.doAction({
+                        type: "ir.actions.client", tag: "reload"
+                    });
+                }
+            });
+        });
+    }
+});

--- a/release_note/static/src/scss/backend.scss
+++ b/release_note/static/src/scss/backend.scss
@@ -1,0 +1,5 @@
+.o_release_note_template {
+    h2 {
+        font-size: 1rem;
+    }
+}

--- a/release_note/templates/release_note.xml
+++ b/release_note/templates/release_note.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="release_note_template">
+        <div class="o_release_note_template d-flex flex-column gap-3">
+            <t t-foreach="items" t-as="item">
+                <t t-call="release_note.release_note_item_template" />
+            </t>
+        </div>
+    </template>
+
+    <template id="release_note_item_template">
+        <div class="card">
+            <div class="card-body">
+                <h1 class="card-title border-bottom pb-1 mb-3">
+                    <t t-esc="item['version']" />
+                    <small class="text-muted" t-esc="item['date']" />
+                </h1>
+                <div class="card-text px-3">
+                    <t t-raw="item['content']"/>
+                </div>
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/release_note/tests/__init__.py
+++ b/release_note/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_release_note

--- a/release_note/tests/fixtures/NEWS-malformated.md
+++ b/release_note/tests/fixtures/NEWS-malformated.md
@@ -1,0 +1,5 @@
+This file does not follow the expected release note heading format.
+
+## Not matching
+- item 1
+- item 2

--- a/release_note/tests/fixtures/NEWS-unordered.md
+++ b/release_note/tests/fixtures/NEWS-unordered.md
@@ -1,0 +1,8 @@
+# CURQ 18.0.0 (2026-01-10)
+- Added feature for 18
+
+# CURQ 19.0.1 (2026-01-13)
+- Added feature for 19.0.1
+
+# CURQ 19.0.0 (2026-01-11)
+- Added feature for 19

--- a/release_note/tests/fixtures/NEWS-version-variants.md
+++ b/release_note/tests/fixtures/NEWS-version-variants.md
@@ -1,0 +1,8 @@
+# CURQ v1.2.3 (2026-01-10)
+- Added feature A
+
+# CURQ 1.2 (2026-01-09)
+- Added feature B
+
+# CURQ 1 (2026-01-08)
+- Added feature C

--- a/release_note/tests/test_release_note.py
+++ b/release_note/tests/test_release_note.py
@@ -1,0 +1,108 @@
+from os.path import dirname, join
+from pathlib import Path
+from unittest.mock import patch
+
+from odoo.tests import common
+
+from odoo.addons.release_note.wizards.release_note_wizard import ReleaseNoteWizard
+
+
+class TestReleaseNote(common.TransactionCase):
+    @classmethod
+    def _read_fixture(cls, filename):
+        data_dir = Path(join(dirname(__file__), "fixtures"))
+        return (data_dir / filename).read_text()
+
+    def test_empty_news_file(self):
+        fixture_content = self._read_fixture("NEWS-empty.md")
+
+        with patch.object(
+            ReleaseNoteWizard, "_get_release_notes", return_value=fixture_content
+        ):
+            parsed = self.env["release.note.wizard"]._parse_release_notes()
+
+        self.assertEqual(parsed, [])
+
+    def test_malformed_news_file(self):
+        """If the NEWS file is malformated, we don't want the system to crash,
+        but simply consider that there is no release note to show."""
+        fixture_content = self._read_fixture("NEWS-malformated.md")
+
+        with patch.object(
+            ReleaseNoteWizard, "_get_release_notes", return_value=fixture_content
+        ):
+            parsed = self.env["release.note.wizard"]._parse_release_notes()
+
+        self.assertEqual(parsed, [])
+
+    def test_different_versioning_no_error(self):
+        fixture_content = self._read_fixture("NEWS-version-variants.md")
+
+        with patch.object(
+            ReleaseNoteWizard, "_get_release_notes", return_value=fixture_content
+        ):
+            parsed = self.env["release.note.wizard"]._parse_release_notes()
+
+        self.assertEqual(len(parsed), 3)
+        self.assertEqual([note["version"] for note in parsed], ["v1.2.3", "1.2", "1"])
+
+    def test_mixed_version_length(self):
+        fixture_content = self._read_fixture("NEWS-version-variants.md")
+        user = self.env.ref("base.user_demo")
+        user.last_release_note_version = "1.1"
+        wizard = self.env["release.note.wizard"].create({"user_id": user.id})
+
+        with patch.object(
+            ReleaseNoteWizard, "_get_release_notes", return_value=fixture_content
+        ):
+            new_notes = wizard._new_release_notes()
+
+        self.assertEqual([note["version"] for note in new_notes], ["v1.2.3", "1.2"])
+
+    def test_news_is_unordered(self):
+        """Allow NEWS file to be unordered for flexibility"""
+        fixture_content = self._read_fixture("NEWS-unordered.md")
+
+        with patch.object(
+            ReleaseNoteWizard, "_get_release_notes", return_value=fixture_content
+        ):
+            self.env["release.note.wizard"]._register_hook()
+
+        current_version = self.env["ir.config_parameter"].get_param(
+            "release_note.current_version", default="0.0.0"
+        )
+        self.assertEqual(current_version, "19.0.1")
+
+    def test_new_user(self):
+        """Test that a new user (without last_release_note_version) is considered to have read the
+        current version, to avoid overwhelming them with old release notes.
+        """
+        current_version = "18.0.9"
+        self.env["ir.config_parameter"].set_param(
+            "release_note.current_version", current_version
+        )
+
+        user = (
+            self.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": "Release Note New User",
+                    "login": "release_note_new_user",
+                }
+            )
+        )
+
+        self.assertEqual(user.last_release_note_version, current_version)
+
+    def test_logs_when_news_file_missing(self):
+        logger_name = "odoo.addons.release_note.wizards.release_note_wizard"
+
+        with self.assertLogs(logger_name, level="WARNING"):
+            with patch(
+                "odoo.addons.release_note.wizards.release_note_wizard.file_path",
+                side_effect=FileNotFoundError,
+            ):
+                content = self.env["release.note.wizard"]._get_release_notes_from_file()
+
+        self.assertEqual(content, "")

--- a/release_note/utils.py
+++ b/release_note/utils.py
@@ -1,0 +1,11 @@
+def version_to_tuple(version):
+    """Converts a version string like 'v1.2.3' to a tuple (1, 2, 3) for easy comparison.
+    If the version string is invalid, returns (0, 0, 0).
+    """
+    if not version:
+        return (0, 0, 0)
+
+    try:
+        return tuple(int(part) for part in version.removeprefix("v").split("."))
+    except ValueError:
+        return (0, 0, 0)

--- a/release_note/views/res_config_settings_view.xml
+++ b/release_note/views/res_config_settings_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//widget[@name='res_config_edition']" position="before">
+                <setting
+                    id="release_note"
+                    invisible="not release_note_version or release_note_version == '0.0.0'"
+                >
+                    <field name="release_note_project" class="oe_inline fw-bold pe-1" nolabel="1" />
+                    <field name="release_note_version" class="oe_inline"/>
+                    <button
+                        name="%(release_note_wizard_action)d"
+                        string="View Release Notes"
+                        context="{'default_include_read': True}"
+                        class="btn-link d-block"
+                        type="action"
+                    />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/release_note/wizards/__init__.py
+++ b/release_note/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import release_note_wizard

--- a/release_note/wizards/release_note_wizard.py
+++ b/release_note/wizards/release_note_wizard.py
@@ -1,0 +1,147 @@
+import logging
+import re
+
+import markdown
+
+from odoo import api, fields, models
+from odoo.tools import file_path
+
+from ..utils import version_to_tuple
+
+_logger = logging.getLogger(__name__)
+
+
+class ReleaseNoteWizard(models.TransientModel):
+    _name = "release.note.wizard"
+    _description = "Release Notes"
+
+    user_id = fields.Many2one(
+        comodel_name="res.users", required=True, default=lambda self: self.env.user
+    )
+    include_read = fields.Boolean(default=False)
+    news = fields.Html(compute="_compute_news", readonly=True)
+
+    def _register_hook(self):
+        super()._register_hook()
+        release_notes = self._parse_release_notes()
+
+        current_version = "0.0.0"
+        project_name = "Odoo"
+        if release_notes:
+            # Find the latest version among the release notes
+            last_release = max(
+                release_notes, key=lambda note: version_to_tuple(note["version"])
+            )
+            current_version = last_release["version"]
+            project_name = last_release["project"]
+
+        # Store the version and project name in ir.config_parameter
+        self.env["ir.config_parameter"].sudo().set_param(
+            "release_note.current_version", current_version
+        )
+        self.env["ir.config_parameter"].sudo().set_param(
+            "release_note.project", project_name
+        )
+
+        version_tuple = version_to_tuple(current_version)
+
+        # If the user has unread release notes, we want to show the wizard on startup, so we set the flag.
+        for user in self.env["res.users"].search([]):
+            # Make sure on installation we don't mark all release notes as unread for all users.
+            if not user.last_release_note_version:
+                user.last_release_note_version = current_version
+            user.has_unread_release_note = (
+                version_to_tuple(user.last_release_note_version) < version_tuple
+            )
+
+    @api.model
+    def _get_release_notes_from_file(self):
+        try:
+            file_location = file_path("NEWS.md")
+            return open(file_location, "r").read()
+        except FileNotFoundError:
+            _logger.warning("NEWS.md file not found.")
+            return ""
+
+    @api.model
+    def _get_release_notes(self):
+        """Override this method to change the source of the release notes.
+        By default, it reads from a file
+        """
+        return self._get_release_notes_from_file()
+
+    @api.model
+    def _get_release_note_header_regex(self):
+        """Override this method if your release note have a different format."""
+        return r"^#\ (?P<project>.*?)\ (?P<version>[^\ ]+)\ \((?P<date>[^)]+)\)\s*\n(?P<content>.*?)(?=^#\ |\Z)"
+
+    @api.model
+    def _parse_release_notes(self):
+        """Returns a list of dicts (project, version_tuple, version, date, content) for each release note."""
+        release_note = self._get_release_notes()
+        release_notes = []
+
+        regex_expression = self._get_release_note_header_regex()
+        matches = re.findall(regex_expression, release_note, re.DOTALL | re.MULTILINE)
+        for match in matches:
+            project, version, date, content = match
+            release_notes.append(
+                {
+                    "project": project,
+                    "version_tuple": version_to_tuple(version),
+                    "version": version,
+                    "date": date,
+                    "content": markdown.markdown(content.strip()),
+                }
+            )
+        return release_notes
+
+    def _new_release_notes(self):
+        """Returns the release notes that are new to the user."""
+        self.ensure_one()
+        all_release_notes = self._parse_release_notes()
+        last_read_version = (0, 0, 0)
+        if self.user_id.last_release_note_version:
+            last_read_version = version_to_tuple(self.user_id.last_release_note_version)
+        new_release_notes = [
+            note
+            for note in all_release_notes
+            if note["version_tuple"] > last_read_version
+        ]
+        return new_release_notes
+
+    @api.depends("user_id", "user_id.last_release_note_version", "include_read")
+    def _compute_news(self):
+        for wizard in self:
+            new_release_notes = (
+                wizard._parse_release_notes()
+                if wizard.include_read
+                else wizard._new_release_notes()
+            )
+            news_as_html = self.env["ir.qweb"]._render(
+                "release_note.release_note_template", {"items": new_release_notes}
+            )
+            wizard.news = news_as_html
+
+    @api.model
+    def action_open_release_notes(self):
+        """Open release notes wizard if there are unread release notes,
+        otherwise do nothing.
+        """
+        user = self.env.user
+        if not user.has_unread_release_note:
+            return
+        return self.env["ir.actions.act_window"]._for_xml_id(
+            "release_note.release_note_wizard_action"
+        )
+
+    @api.model
+    def mark_release_notes_as_read(self):
+        """Mark the release notes as read for the current user."""
+        current_version = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("release_note.current_version", default="0.0.0")
+        )
+        self.env.user.last_release_note_version = current_version
+        self.env.user.has_unread_release_note = False

--- a/release_note/wizards/release_note_wizard_view.xml
+++ b/release_note/wizards/release_note_wizard_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="release_note_wizard_view" model="ir.ui.view">
+        <field name="model">release.note.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Release Notes">
+                <field name="user_id" invisible="1"/>
+                <field name="news" />
+                <footer>
+                    <button special="cancel" class="btn-primary" string="Close"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="release_note_wizard_action" model="ir.actions.act_window">
+        <field name="name">Release Notes</field>
+        <field name="res_model">release.note.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,24 @@
+[tool.towncrier]
+name = "CURQ"
+directory = "newsfragments"
+filename = "NEWS.md"
+issue_format = "[#{issue}](https://github.com/onesteinbv/addons-curq/pull/{issue})"
+
+[[tool.towncrier.type]]
+directory = "feat"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "imp"
+name = "Improvements"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fix"
+name = "Fixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+name = "misc"
+showcontent = false


### PR DESCRIPTION
**Release notes feature:**

* Added a new `release_note`  that shows a release notes dialog to users after updates,
* Updated `Dockerfile` to include the `release_note` module and copy `NEWS.md` into the build, ensuring release notes are available in deployments.

**News fragment workflow:**

* Added a new GitHub Actions workflow (`validate-newsfragment.yml`) to ensure every pull request to the `18.0` branch includes a valid Towncrier news fragment unless labeled otherwise.
* Added a `CONTRIBUTING.md` file with instructions on when and how to add news fragments, including naming conventions and writing guidelines.

**CI/CD and workflow updates:**

* Refactored and renamed the release workflow to `tag.yml`, adding a Telegram notification step, a check for dangling news fragments before builds, and removing the automatic GitHub release creation.
* Releases will now on be created and curated manually