### PR TITLE
[FIX] calendar_branding: resolve @class XPath warnings in views

### DIFF
--- a/calendar_branding/views/calendar_branding_views.xml
+++ b/calendar_branding/views/calendar_branding_views.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <odoo>
     <record id="view_calendar_event_form_inherit" model="ir.ui.view">
         <field name="name">calendar.event.form.inherit.branding</field>
         <field name="model">calendar.event</field>
         <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='set_discuss_videocall_location']/span[not(contains(@class, 'fa'))]" position="replace">
+            <xpath expr="//button[@name='set_discuss_videocall_location']/span[not(hasclass('fa'))]" position="replace">
                 <span> CURQ Meeting</span>
             </xpath>
         </field>
@@ -16,7 +15,7 @@
         <field name="model">calendar.event</field>
         <field name="inherit_id" ref="calendar.view_calendar_event_form_quick_create"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='set_discuss_videocall_location']/span[not(contains(@class, 'fa'))]" position="replace">
+            <xpath expr="//button[@name='set_discuss_videocall_location']/span[not(hasclass('fa'))]" position="replace">
                 <span>CURQ Meeting</span>
             </xpath>
         </field>


### PR DESCRIPTION
Resolves Odoo 18 UI view warnings where `@class` was used in XPath expressions for `calendar.event.form.inherit.branding` and  `calendar.event.form.quick_create.inherit.branding`.
