### PR TITLE
[FIX] test worfklow: Exclude bundles in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,11 @@ jobs:
           echo "ADDONS_PATH=$addons_path" >> $GITHUB_ENV
       - name: Install external dependencies
         run: |
+          selection_flags=$(echo $ADDONS_PATH | sed 's/,/ -d /g' | sed 's/^/-d /')
           bundles=$(find . -mindepth 1 -maxdepth 1 -type d -name '*_install' -printf '%f,' | sed 's/,$//')
-          external_deps=$(manifestoo --select "$bundles" --exclude-core-addons list-external-dependencies python --transitive --separator ' ')
+          external_deps=$(manifestoo $selection_flags --select-exclude "$bundles" --exclude-core-addons list-external-dependencies python --transitive --separator ' ')
           pip3 install $external_deps pdfminer.six==20220319
+          echo "EXCLUDE=$bundles" >> $GITHUB_ENV
       - name: Check licenses
         run: manifestoo -d . check-dev-status --default-dev-status=Beta
       - name: Initialize test db

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,7 @@ jobs:
           name: Screenshots of failed JS tests - ${{ matrix.name }}${{ join(matrix.include) }}
           path: /tmp/odoo_tests/${{ env.PGDATABASE }}
           if-no-files-found: ignore
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Aggregate repos.yaml
         run: |
           set -x
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           pip install git-aggregator
           gitaggregate -c repos.yaml
           addons_path=$ADDONS_PATH,$(find $(pwd)/* -name .git -exec dirname {} \; -not -name odoo | uniq | tr '\n' ',' | sed 's/,$//'),.

--- a/repos.yaml
+++ b/repos.yaml
@@ -26,7 +26,7 @@
     onestein: https://github.com/onesteinbv/addons-oca.git
   merges:
     - remote: onestein
-      ref: 7ad1b2328ad1afa32854a0507a7417ca165dd5ca
+      ref: 98ea8c2c60b69172c3ee14de3d6bf3fc2a8ce03f
 
 # third-party
 ./addons-third-party:

--- a/repos.yaml
+++ b/repos.yaml
@@ -16,7 +16,7 @@
     onestein: https://github.com/onesteinbv/addons-generic.git
   merges:
     - remote: onestein
-      ref: b1572cda2393e96e72aa2f5d441accf1cb6bbe04
+      ref: c7703cdff7edefda539667050e17c3b1eb6b51c9
 
 # oca
 ./oca:

--- a/repos.yaml
+++ b/repos.yaml
@@ -16,7 +16,7 @@
     onestein: https://github.com/onesteinbv/addons-generic.git
   merges:
     - remote: onestein
-      ref: c7703cdff7edefda539667050e17c3b1eb6b51c9
+      ref: 2b8363d01365ad58892a6553cf764799f5c37850
 
 # oca
 ./oca:


### PR DESCRIPTION
Bundles are just modules with purely dependencies to other modules, we don't need to test them as the underlying modules are already tested in OCA / other repositories